### PR TITLE
Add Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+LICENSE
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ package-lock.json
 fly.toml
 *.fiber.gz
 soundcloak.json
-Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+ARG GO_VERSION=1.21.3
+ARG NODE_VERSION=bookworm
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS build
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /build
+COPY . .
+RUN go install github.com/a-h/templ/cmd/templ@latest && \
+  templ generate && \
+  CGO_ENABLED=0 GOARCH=${TARGETARCH} GOOS=${TARGETOS} go build -ldflags "-s -w -extldflags '-static'" -o ./app
+
+FROM node:${NODE_VERSION} AS node
+WORKDIR /hls.js
+COPY --from=build /build/package.json ./
+RUN npm i
+
+FROM scratch
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /build/assets /assets
+COPY --from=build /build/app /app
+COPY --from=node /hls.js/node_modules /node_modules
+
+EXPOSE 4664
+
+ENTRYPOINT ["/app"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  soundcloak:
+    container_name: soundcloak
+    restart: unless-stopped
+    build: .
+    ports:
+      - "127.0.0.1:4664:4664"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - ./soundcloak.json:/soundcloak.json


### PR DESCRIPTION
This pull request introduces a streamlined Docker image for soundcloak with hls.js. The image is statically compiled using the official Debian image for Go version 1.21.3.

Additionally, I have included a compose.yaml file with an example configuration for ease of use.

To enhance user experience, I propose providing an soundcloak.json.example file. This will allow users to reference a template rather than having to sift through the code to create their own JSON file.

Furthermore, I believe it would be beneficial to incorporate environment variables for all configuration options. This would enable users to manage their settings more conveniently, either by omitting configuration files altogether or by utilizing environment variables for streamlined management within Docker.

Final image is ~29.3MB (after decompression)