### PR TITLE
Add Opensearch XML support

### DIFF
--- a/static/assets/opensearch.xml
+++ b/static/assets/opensearch.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+    <ShortName>SoundCloak</ShortName>
+    <Description>Frontend for SoundCloud</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <LongName>SoundCloak</LongName>
+    <Url rel="results" type="text/html" method="get" template="/_/search?q={searchTerms}" />
+    <Url type="application/opensearchdescription+xml"
+         rel="self"
+         template="/opensearch.xml?method=GET" />
+</OpenSearchDescription>

--- a/templates/base.templ
+++ b/templates/base.templ
@@ -11,6 +11,7 @@ templ Base(title string, content templ.Component, head templ.Component) {
 			<link rel="stylesheet" href="/_/static/global.css"/>
 			<link rel="stylesheet" href="/_/static/instance.css"/>
 			<link rel="icon" href="/_/static/favicon.ico"/>
+			<link rel="search" type="application/opensearchdescription+xml" title="SoundCloak" href="/_/assets/opensearch.xml"/>
 			<title>
 				if title != "" {
 					{ title } ~


### PR DESCRIPTION
It allows to add SoundCloak instance as a search engine, or website to be searchable from address\search field.
As an example, this is how it works under Firefox.
<img width="776" height="414" alt="firefox" src="https://github.com/user-attachments/assets/a6464ada-d0b2-40f8-9da4-afe20877356e" />
