### PR TITLE
Adds HLS FairPlay Support

### DIFF
--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -17,7 +17,7 @@
 | Proxy song streams  | ProxyStreams      | same as ProxyStreams in backend config | true, false     | Proxy song streams through the backend. ProxyStreams must be enabled on the backend |
 | Fully preload track | FullyPreloadTrack | false                                  | true, false     | Fully load track when the page is loaded (track stream expires in ~5 minutes)       |
 | Streaming audio     | HLSAudio          | "mpeg"                                 | "aac_hq", "aac", "mpeg", "aac_lq"   | What [audio preset](AUDIO_PRESETS.md) should be loaded when streaming audio          |
-| Widevine DRM  | DRM      | false | true, false     | Allow playing tracks that soundcloud recently started locking behind DRM. Downloads still won't work, but at least you can play it if you enable DRM in your browser. If you enable ProxyStreams, the DRM license API will also be proxied |
+| DRM (Widevine / FairPlay)  | DRM      | false | true, false     | Allow playing tracks that SoundCloud recently started locking behind DRM. Requires the HLS player and at least one of `Restream` or `ProxyStreams` enabled in the backend. The `Restream`/`ProxyStreams` requirement applies to all HLS playback, including non-DRM tracks. The key system is chosen per browser: Widevine on non-Apple browsers, FairPlay on Safari. Downloads still won't work. Widevine uses the instance license proxy when `ProxyStreams` is enabled; FairPlay licenses are always proxied. |
 
 ## Restream Player
 

--- a/lib/cfg/misc.go
+++ b/lib/cfg/misc.go
@@ -111,7 +111,7 @@ type Preferences struct {
 
 	Waveform *bool // show waveform
 
-	DRM *bool // allow playing DRM tracks with HLS player (widevine, decryption on your device)
+	DRM *bool // allow playing DRM tracks with HLS player (widevine on non-Apple, fairplay on Safari; decryption on your device)
 }
 
 func B2s(b []byte) string {

--- a/lib/proxy_streams/init.go
+++ b/lib/proxy_streams/init.go
@@ -2,6 +2,7 @@ package proxystreams
 
 import (
 	"bytes"
+	"encoding/base64"
 	"time"
 
 	"git.maid.zone/stuff/soundcloak/lib/cfg"
@@ -65,7 +66,12 @@ func Load(app *fiber.App) {
 			p.HLSAudio = &v
 		}
 
-		tr := t.Media.SelectCompatibleAnyHLS(p)
+		var drmProtocol sc.Protocol = sc.ProtocolCTREncryptedHLS
+		if sc.FairPlayCapable(string(c.RequestCtx().UserAgent())) {
+			drmProtocol = sc.ProtocolCBCEncryptedHLS
+		}
+
+		tr := t.Media.SelectCompatibleAnyHLS(p, drmProtocol)
 		if tr == nil {
 			return fiber.ErrExpectationFailed
 		}
@@ -425,6 +431,49 @@ func Load(app *fiber.App) {
 			return sc.DoWithRetry(misc.HlsAacClient, req, c.Response())
 		})
 	}
+
+	app.All("/_/api/fp", func(c fiber.Ctx) error {
+		req := c.Request()
+		method := string(c.Method())
+
+		req.Header.Reset()
+		req.Header.SetMethod(method)
+		req.Header.SetUserAgent(cfg.UserAgent)
+		req.URI().SetScheme("https")
+		req.URI().SetHost("license.media-streaming.soundcloud.cloud")
+		req.URI().SetPath("/playback/fairplay")
+
+		if method == "GET" {
+			return sc.DoWithRetry(misc.HlsAacClient, req, c.Response())
+		}
+
+		spc := base64.StdEncoding.EncodeToString(req.Body())
+		assetID := string(req.URI().QueryArgs().Peek("assetId"))
+		req.ResetBody()
+		req.Header.SetMethod(method)
+		req.Header.SetUserAgent(cfg.UserAgent)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.URI().SetScheme("https")
+		req.URI().SetHost("license.media-streaming.soundcloud.cloud")
+		req.URI().SetPath("/playback/fairplay")
+		req.SetBodyString("spc=" + spc + "&assetId=" + assetID)
+
+		if err := sc.DoWithRetry(misc.HlsAacClient, req, c.Response()); err != nil {
+			return err
+		}
+
+		if c.Response().StatusCode() == 200 {
+			ckc := c.Response().Body()
+			ckc = bytes.TrimSpace(ckc)
+			dec, err := base64.StdEncoding.DecodeString(string(ckc))
+			if err == nil {
+				c.Response().ResetBody()
+				c.Response().SetBody(dec)
+				c.Response().Header.Set("Content-Type", "application/octet-stream")
+			}
+		}
+		return nil
+	})
 
 	// deprecated kind of, will remove at some point
 	if cfg.ProxyStreams {

--- a/lib/sc/init.go
+++ b/lib/sc/init.go
@@ -26,6 +26,7 @@ import (
 )
 
 var ProxyErr = errors.New("could not connect to proxy")
+var ErrHLSNotConfigured = errors.New("HLS unavailable: enable Restream or ProxyStreams")
 var parsedproxy string
 
 var auth_state atomic.Int64
@@ -293,6 +294,10 @@ func DoWithRetryAll(httpc *fasthttp.Client, req *fasthttp.Request, resp *fasthtt
 
 // Since the http client is setup to always keep connections idle (great for speed, no need to open a new one everytime), those connections may be closed by soundcloud after some time of inactivity, this ensures that we retry those requests that fail due to the connection closing/timing out
 func DoWithRetry(httpc *fasthttp.HostClient, req *fasthttp.Request, resp *fasthttp.Response) (err error) {
+	if httpc == nil {
+		return ErrHLSNotConfigured
+	}
+
 	for range 10 {
 		err = httpc.Do(req, resp)
 		if err == nil {

--- a/lib/sc/track.go
+++ b/lib/sc/track.go
@@ -1,6 +1,7 @@
 package sc
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -77,6 +78,19 @@ const (
 	ProtocolCTREncryptedHLS Protocol = "ctr-encrypted-hls" // google's widevine && microsoft playready
 	ProtocolCBCEncryptedHLS Protocol = "cbc-encrypted-hls" // apple's fairplay
 )
+
+func FairPlayCapable(ua string) bool {
+	if !strings.Contains(ua, "AppleWebKit") {
+		return false
+	}
+	for _, s := range []string{"Chrome", "CriOS", "Firefox", "FxiOS", "Edg", "OPR", "SamsungBrowser", "Yandex"} {
+		if strings.Contains(ua, s) {
+			return false
+		}
+	}
+	return strings.Contains(ua, "iPhone") || strings.Contains(ua, "iPad") ||
+		strings.Contains(ua, "iPod") || strings.Contains(ua, "Mac")
+}
 
 type Format struct {
 	Protocol Protocol `json:"protocol"`
@@ -672,7 +686,7 @@ func (m Media) SelectCompatibleHLS(mode string) *Transcoding {
 	return nil
 }
 
-func (m Media) SelectCompatibleHLSDRM(mode string) *Transcoding {
+func (m Media) SelectCompatibleHLSDRM(mode string, drm Protocol) *Transcoding {
 	// aac_hq - aac_256k, aac_160k, mp3,      aac_96k
 	// aac    - aac_160k, aac_256k, mp3,      aac_96k
 	// mpeg   - mp3,      aac_256k, aac_160k, aac_96k
@@ -685,7 +699,7 @@ func (m Media) SelectCompatibleHLSDRM(mode string) *Transcoding {
 	switch mode {
 	case cfg.AudioAACHQ:
 		for _, t := range m.Transcodings {
-			if t.Format.Protocol == ProtocolCTREncryptedHLS {
+			if t.Format.Protocol == drm {
 				switch t.Preset {
 				case "aac_256k":
 					t.SoundcloakPreset = cfg.AudioAACHQ
@@ -718,7 +732,7 @@ func (m Media) SelectCompatibleHLSDRM(mode string) *Transcoding {
 		}
 	case cfg.AudioAAC:
 		for _, t := range m.Transcodings {
-			if t.Format.Protocol == ProtocolCTREncryptedHLS {
+			if t.Format.Protocol == drm {
 				switch t.Preset {
 				case "aac_256k":
 					if b[0] == nil {
@@ -751,7 +765,7 @@ func (m Media) SelectCompatibleHLSDRM(mode string) *Transcoding {
 		}
 	case cfg.AudioMP3:
 		for _, t := range m.Transcodings {
-			if t.Format.Protocol == ProtocolCTREncryptedHLS {
+			if t.Format.Protocol == drm {
 				switch t.Preset {
 				case "aac_256k":
 					if b[0] == nil {
@@ -784,7 +798,7 @@ func (m Media) SelectCompatibleHLSDRM(mode string) *Transcoding {
 		}
 	case cfg.AudioAACLQ:
 		for _, t := range m.Transcodings {
-			if t.Format.Protocol == ProtocolCTREncryptedHLS {
+			if t.Format.Protocol == drm {
 				switch t.Preset {
 				case "aac_256k":
 					if b[2] == nil {
@@ -869,9 +883,9 @@ func (m Media) HasDRM() bool {
 	return false
 }
 
-func (m Media) SelectCompatibleAnyHLS(prefs cfg.Preferences) *Transcoding {
+func (m Media) SelectCompatibleAnyHLS(prefs cfg.Preferences, drm Protocol) *Transcoding {
 	if *prefs.DRM {
-		t := m.SelectCompatibleHLSDRM(*prefs.HLSAudio)
+		t := m.SelectCompatibleHLSDRM(*prefs.HLSAudio, drm)
 		if t != nil {
 			return t
 		}
@@ -1052,6 +1066,7 @@ type CachedStream struct {
 	LegacyHlsAacInit *fasthttp.URI
 	License          string
 	FreshBase        bool
+	KeyID            string
 }
 
 var StreamCache = map[string]Cached[CachedStream]{}
@@ -1121,6 +1136,58 @@ func (tr Transcoding) GetStream(slug string, t Track) (Cached[CachedStream], err
 		StreamCacheMut.Unlock()
 	}
 	return s, err
+}
+
+func (tr Transcoding) FairPlayKeyID(slug string, t Track) string {
+	if slug == "" {
+		slug = tr.Slug(t)
+	}
+
+	StreamCacheMut.RLock()
+	s, ok := StreamCache[slug]
+	StreamCacheMut.RUnlock()
+	if ok && s.Value.KeyID != "" {
+		return s.Value.KeyID
+	}
+
+	cs, err := tr.GetStream(slug, t)
+	if err != nil {
+		return ""
+	}
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.SetURI(cs.Value.Playlist)
+	req.Header.SetUserAgent(cfg.UserAgent)
+
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	if err := DoWithRetry(misc.HlsAacClient, req, resp); err != nil {
+		return ""
+	}
+	body, err := resp.BodyUncompressed()
+	if err != nil {
+		body = resp.Body()
+	}
+
+	i := bytes.Index(body, []byte(`URI="skd://`))
+	if i == -1 {
+		return ""
+	}
+	rest := body[i+len(`URI="skd://`):]
+	keyID := rest
+	if j := bytes.IndexByte(rest, '"'); j != -1 {
+		keyID = rest[:j]
+	}
+	if len(keyID) != 32 {
+		return ""
+	}
+
+	cs.Value.KeyID = string(keyID)
+	StreamCacheMut.Lock()
+	StreamCache[slug] = cs
+	StreamCacheMut.Unlock()
+	return cs.Value.KeyID
 }
 
 func (tr Transcoding) GetUncachedStream(slug string, t Track) (Stream, error) {

--- a/main.go
+++ b/main.go
@@ -937,10 +937,14 @@ Disallow: /`)
 		displayErr := ""
 		var stream sc.Stream
 		var tr *sc.Transcoding
+		var drmProtocol sc.Protocol = sc.ProtocolCTREncryptedHLS
+		if sc.FairPlayCapable(string(c.UserAgent())) {
+			drmProtocol = sc.ProtocolCBCEncryptedHLS
+		}
 
 		if *prefs.Player != cfg.NonePlayer {
 			if *prefs.Player == cfg.HLSPlayer {
-				tr = track.Media.SelectCompatibleAnyHLS(prefs)
+				tr = track.Media.SelectCompatibleAnyHLS(prefs, drmProtocol)
 				if tr == nil {
 					err = sc.ErrIncompatibleStream
 				} else {
@@ -951,7 +955,11 @@ Disallow: /`)
 					if tr.HasDRM() {
 						var cs sc.Cached[sc.CachedStream]
 						cs, err = tr.GetStream("", track)
-						if *prefs.ProxyStreams {
+						if err != nil {
+							displayErr = err.Error()
+						} else if tr.Format.Protocol == sc.ProtocolCBCEncryptedHLS {
+							stream.License = "/_/api/fp?license_token=" + cs.Value.License + "&assetId=" + tr.FairPlayKeyID("", track)
+						} else if *prefs.ProxyStreams {
 							stream.License = "/_/api/wv?license_token=" + cs.Value.License
 						} else {
 							stream.License = "https://license.media-streaming.soundcloud.cloud/playback/widevine?license_token=" + cs.Value.License

--- a/static/assets/player.js
+++ b/static/assets/player.js
@@ -7,7 +7,10 @@ if (Hls.isSupported()) {
     var lic = audio.getAttribute("license");
     if (lic) {
         opts.emeEnabled = true;
-        opts.drmSystems = { "com.widevine.alpha": { "licenseUrl": lic } };
+        opts.drmSystems = {
+            "com.widevine.alpha": { "licenseUrl": lic },
+            "com.apple.fps": { "licenseUrl": lic, "serverCertificateUrl": lic }
+        };
     }
     var hls = new Hls(opts);
     hls.loadSource(audio.src);

--- a/templates/preferences.templ
+++ b/templates/preferences.templ
@@ -127,7 +127,7 @@ templ Preferences(prefs cfg.Preferences) {
 					@sel_audio("HLSAudio", *prefs.HLSAudio)
 				</label>
 				<label>
-					Widevine DRM:
+					DRM (Widevine / FairPlay):
 					@checkbox("DRM", *prefs.DRM)
 				</label>
 			case cfg.RestreamPlayer:

--- a/templates/track.templ
+++ b/templates/track.templ
@@ -118,6 +118,11 @@ templ TrackPlayer(prefs cfg.Preferences, track sc.Track, transcoding *sc.Transco
 		if *prefs.Waveform {
 			@track.RenderWaveform()
 		}
+		if *prefs.Player == cfg.HLSPlayer && !cfg.Restream && !cfg.ProxyStreams {
+			<div>
+				<p>HLS playback is not configured correctly. ProxyStreams or Restream must be enabled.</p>
+			</div>
+		}
 		if track.Policy == sc.PolicySnip {
 			<div>
 				<p>Only a 30-second snippet is available.</p>
@@ -134,7 +139,7 @@ templ TrackPlayer(prefs cfg.Preferences, track sc.Track, transcoding *sc.Transco
 					case cfg.RestreamPlayer, cfg.ProgressivePlayer:
 						<a href="/_/preferences">You can enable HLS player and DRM in preferences</a>. You must also enable it in your browser settings
 				}
-			</p>
+				</p>
 			</div>
 		}
 		if *prefs.ShowAudio {


### PR DESCRIPTION
Adds FairPlay DRM support for Safari and iOS through the HLS player.

FairPlay media can still be delivered directly from SoundCloud when ProxyStreams is disabled. However, FairPlay license exchange requires server-side handling: Safari sends an SPC request to the instance, the instance obtains the CKC response from SoundCloud’s FairPlay license service, and returns it to Safari for decryption.

Widevine behavior remains unchanged.